### PR TITLE
feat: Add `wordplay/prepare.py`

### DIFF
--- a/src/wordplay/prepare.py
+++ b/src/wordplay/prepare.py
@@ -1,0 +1,81 @@
+"""
+Prepare the Shakespeare dataset for character-level language modeling.
+So instead of encoding with GPT-2 BPE tokens, we just map characters to ints.
+Will save train.bin, val.bin containing the ids, and meta.pkl containing the
+encoder and decoder and some other related info.
+"""
+from __future__ import absolute_import, annotations, division, print_function
+import os
+import pickle
+import requests
+import numpy as np
+from pathlib import Path
+
+HERE = Path(os.path.abspath(__file__)).parent
+HF_DATASETS_CACHE = HERE / ".cache" / "huggingface"
+HF_DATASETS_CACHE.mkdir(parents=True, exist_ok=True)
+os.environ['HF_DATASETS_CACHE'] = HF_DATASETS_CACHE.as_posix()
+print(f'Using HF_DATASETS_CACHE={HF_DATASETS_CACHE.as_posix()}')
+
+DATA_DIR = Path(os.getcwd()) / 'data' / 'shakespeare_char'
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+print(f'Output directory for processed data: {DATA_DIR}')
+
+# download the tiny shakespeare dataset
+input_file_path = os.path.join(DATA_DIR, 'input.txt')
+if not os.path.exists(input_file_path):
+    data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'
+    with open(input_file_path, 'w') as f:
+        f.write(requests.get(data_url).text)
+
+with open(input_file_path, 'r') as f:
+    data = f.read()
+print(f"length of dataset in characters: {len(data):,}")
+
+# get all the unique characters that occur in this text
+chars = sorted(list(set(data)))
+vocab_size = len(chars)
+print("all the unique characters:", ''.join(chars))
+print(f"vocab size: {vocab_size:,}")
+
+# create a mapping from characters to integers
+stoi = { ch:i for i,ch in enumerate(chars) }
+itos = { i:ch for i,ch in enumerate(chars) }
+def encode(s):
+    return [stoi[c] for c in s] # encoder: take a string, output a list of integers
+def decode(l):
+    return ''.join([itos[i] for i in l]) # decoder: take a list of integers, output a string
+
+# create the train and test splits
+n = len(data)
+train_data = data[:int(n*0.9)]
+val_data = data[int(n*0.9):]
+
+# encode both to integers
+train_ids = encode(train_data)
+val_ids = encode(val_data)
+print(f"train has {len(train_ids):,} tokens")
+print(f"val has {len(val_ids):,} tokens")
+
+# export to bin files
+train_ids = np.array(train_ids, dtype=np.uint16)
+val_ids = np.array(val_ids, dtype=np.uint16)
+train_ids.tofile(os.path.join(DATA_DIR, 'train.bin'))
+val_ids.tofile(os.path.join(DATA_DIR, 'val.bin'))
+
+# save the meta information as well, to help us encode/decode later
+meta = {
+    'vocab_size': vocab_size,
+    'itos': itos,
+    'stoi': stoi,
+}
+print(f"Saving meta information to {DATA_DIR / 'meta.pkl'}")
+with open(os.path.join(DATA_DIR, 'meta.pkl'), 'wb') as f:
+    pickle.dump(meta, f)
+
+# length of dataset in characters:  1115394
+# all the unique characters:
+#  !$&',-.3:;?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+# vocab size: 65
+# train has 1003854 tokens
+# val has 111540 tokens


### PR DESCRIPTION
## Copilot Summary

This pull request introduces a new script, `prepare.py`, to preprocess the Shakespeare dataset for character-level language modeling. The script downloads the dataset, processes it into training and validation splits, encodes characters as integers, and saves the processed data and metadata.

### Dataset Preparation:

* Added functionality to download the Tiny Shakespeare dataset from a specified URL if it is not already present locally. The dataset is saved in the `data/shakespeare_char` directory. (`[src/wordplay/prepare.pyR1-R81](diffhunk://#diff-9faf2f9806f81d5d61fbc868d5fe030eebb80dba734220c966267fef89a0dfd7R1-R81)`)

### Data Processing:

* Extracted unique characters from the dataset, calculated the vocabulary size, and created mappings (`stoi` and `itos`) for encoding characters to integers and decoding integers back to characters. (`[src/wordplay/prepare.pyR1-R81](diffhunk://#diff-9faf2f9806f81d5d61fbc868d5fe030eebb80dba734220c966267fef89a0dfd7R1-R81)`)
* Split the dataset into training (90%) and validation (10%) sets, encoded the splits into integer sequences, and saved them as binary files (`train.bin` and `val.bin`). (`[src/wordplay/prepare.pyR1-R81](diffhunk://#diff-9faf2f9806f81d5d61fbc868d5fe030eebb80dba734220c966267fef89a0dfd7R1-R81)`)

### Metadata Storage:

* Saved metadata, including the vocabulary size and character mappings (`stoi` and `itos`), into a serialized file (`meta.pkl`) for later use. (`[src/wordplay/prepare.pyR1-R81](diffhunk://#diff-9faf2f9806f81d5d61fbc868d5fe030eebb80dba734220c966267fef89a0dfd7R1-R81)`)

## Summary by Sourcery

New Features:
- Add wordplay/prepare.py script to download Tiny Shakespeare, build character-to-integer mappings, split into training and validation sets, encode the text as integer sequences, and export binary data files and metadata